### PR TITLE
Fixed: Regex de telefone

### DIFF
--- a/js/contato.js
+++ b/js/contato.js
@@ -93,7 +93,7 @@ function validarEmail(email) {
 // Função para validar formato de telefone
 function validarTelefone(telefone) {
   // Aceita formatos: (99) 99999-9999 ou 99999999999 ou 9999-9999
-  const regex = /^(\(\d{2}\)\s?)?\d{4,5}[-\s]?\d{4}$|^\d{10,11}$/;
+  const regex = /^[1-9]{2}9[0-9]{8}$/;
   return regex.test(telefone);
 }
 


### PR DESCRIPTION
- Agora o regex aceita apenas números.
- Valida que há dois números antes do dígito 9 obrigatório
- Valida que depois do dígito 9 obrigatório deve ter mais 8 números